### PR TITLE
Implement caching of the audit information token (#10)

### DIFF
--- a/Source/FCSAmerica.McGruff.TokenGenerator/ServiceToken.cs
+++ b/Source/FCSAmerica.McGruff.TokenGenerator/ServiceToken.cs
@@ -139,7 +139,7 @@ namespace FCSAmerica.McGruff.TokenGenerator
             //set { _token = value; }
         }
 
-        private string _auditInfo;
+        protected string _auditInfo;
 
         public string AuditInfo
         {
@@ -339,7 +339,7 @@ namespace FCSAmerica.McGruff.TokenGenerator
         }
 
 
-        private string RefreshAuditInfo()
+        protected virtual string RefreshAuditInfo()
         {
             var request = GetWebRequest(this.AuditInfoServiceEndpoint);
             request.Headers.Add("Authorization", "SAML " + this.Token);

--- a/Source/TokenGenerator.BrowserBased.IntegrationTests/BrowserBasedServiceTokenTests.cs
+++ b/Source/TokenGenerator.BrowserBased.IntegrationTests/BrowserBasedServiceTokenTests.cs
@@ -106,6 +106,7 @@ namespace FCSAmerica.McGruff.TokenGenerator.BrowserBased.IntegrationTests
             var ecsAddress = "https://devinternal.fcsamerica.net/DocuClick/v4/REST/api/Proxy/EnterpriseConfigurationStore/v1/ConfigItems/";
             var cache = A.Fake<ITokenCache>();
             A.CallTo(() => cache.LoadFromCache()).Returns(null);
+            A.CallTo(() => cache.ClearCache()).DoesNothing();
             A.CallTo(() => cache.SaveToCache(A<string>.Ignored)).Throws<Exception>();
             var browserBasedToken = new BrowserBasedServiceToken(ecsAddress, "DocIndexer", "FCSA", cache);
 
@@ -120,11 +121,12 @@ namespace FCSAmerica.McGruff.TokenGenerator.BrowserBased.IntegrationTests
             var ecsAddress = "https://devinternal.fcsamerica.net/DocuClick/v4/REST/api/Proxy/EnterpriseConfigurationStore/v1/ConfigItems/";
             var cache = A.Fake<ITokenCache>();
             A.CallTo(() => cache.LoadFromCache()).Returns("INVALID XML");
+            A.CallTo(() => cache.ClearCache()).DoesNothing();
             var browserBasedToken = new BrowserBasedServiceToken(ecsAddress, "DocIndexer", "FCSA", cache);
 
             var token = browserBasedToken.Token;
 
-            A.CallTo(() => cache.ClearCache()).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => cache.ClearCache()).MustHaveHappened(Repeated.AtLeast.Once);
             A.CallTo(() => cache.SaveToCache(A<string>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
         }
 

--- a/Source/TokenGenerator.BrowserBased/BrowserBasedServiceToken.cs
+++ b/Source/TokenGenerator.BrowserBased/BrowserBasedServiceToken.cs
@@ -19,6 +19,34 @@ namespace FCSAmerica.McGruff.TokenGenerator.BrowserBased
             _cache = cache;
         }
 
+        private void ClearAllCacheInformation()
+        {
+            _token = null;
+            _auditInfo = null;
+            _cache?.ClearCache();
+        }
+
+        protected override string RefreshAuditInfo()
+        {
+            try
+            {
+                _auditInfo = _cache?.LoadAuditInfoFromCache();
+                if (_auditInfo != null)
+                {
+                    return _auditInfo;
+                }
+            }
+            catch
+            {
+                ClearAllCacheInformation();
+            }
+
+            _auditInfo = base.RefreshAuditInfo();
+            _cache?.SaveAuditInfoToCache(_auditInfo);
+
+            return _auditInfo;
+        }
+
         protected override void RefreshToken()
         {
             _traceSource.TraceInformation("\nStarted using BrowserBasedTokenRetriever using {0}.", AuthenticationEndpoint);
@@ -26,7 +54,6 @@ namespace FCSAmerica.McGruff.TokenGenerator.BrowserBased
             try
             {
                 _token = _cache?.LoadFromCache();
-                AuditInfo = _cache?.LoadAuditInfoFromCache();
                 if (_token != null)
                 {
                     SetExpireDateFromToken();
@@ -34,13 +61,12 @@ namespace FCSAmerica.McGruff.TokenGenerator.BrowserBased
             }
             catch
             {
-                _token = null;
-                AuditInfo = null;
-                 _cache?.ClearCache();
+                ClearAllCacheInformation();
             }
 
             if (string.IsNullOrEmpty(_token) || IsExpiredOrAboutToExpire)
             {
+                ClearAllCacheInformation();
                 try
                 {
                     string stsToken = null;
@@ -57,12 +83,9 @@ namespace FCSAmerica.McGruff.TokenGenerator.BrowserBased
                     securityContextRetreiver.SetApartmentState(ApartmentState.STA);
                     securityContextRetreiver.Start();
                     securityContextRetreiver.Join(DefaultTimeoutInMiliSeconds);
-                    AuditInfo = null;
 
                     _token = !string.IsNullOrEmpty(stsToken) ? CleanToken(stsToken) : stsToken;
-
                     _cache?.SaveToCache(_token);
-                    _cache?.SaveAuditInfoToCache(AuditInfo);
 
                     _traceSource.TraceInformation("\nCompleted retrieving token from BrowerBasedTokenRetriever.");
                 }
@@ -70,9 +93,6 @@ namespace FCSAmerica.McGruff.TokenGenerator.BrowserBased
                 {
                     _traceSource.TraceEvent(TraceEventType.Error, 0,
                         "\nException occured during TokenRetriever RetrieveToken.\n" + UnwrapException(ex).ToString());
-
-                    AuditInfo = null;
-                    _cache?.ClearCache();
                 }
 
                 SetExpireDateFromToken();


### PR DESCRIPTION
* Updates to cache the audit information in the browser based token generator as well.

* Fully implemented caching of the audit info token;  allows it to use the cache if it's called before retrieving the token.

* Moved cache file clearing / local variables cache clearing to a single function to aid in clarity.